### PR TITLE
Fix syntax error in ganalytics.php

### DIFF
--- a/ganalytics.php
+++ b/ganalytics.php
@@ -625,7 +625,8 @@ class Ganalytics extends Module
 			'addAction' => Tools::getValue('add') ? 'add' : '',
 			'removeAction' => Tools::getValue('delete') ? 'delete' : '',
 			'extraAction' => Tools::getValue('op'),
-			'qty' => (int)Tools::getValue('qty', 1);
+			'qty' => (int)Tools::getValue('qty', 1)
+		);
 
 		$cart_products = $this->context->cart->getProducts();
 		if (isset($cart_products) && count($cart_products))


### PR DESCRIPTION
Fix the following syntax error:

```
PHP Parse error:  syntax error, unexpected ';', expecting ')' in /var/www/prestashop/modules/ganalytics/ganalytics.php on line 628
```

This bug (introduced in 6f1b2ca66df13a15d2e75d85b3c6327826fc44d0) actually breaks any Prestashop installation with an up to date Google Analytics module!
