### PR TITLE
[-] MO: ganalytics: bad controller names

### DIFF
--- a/ganalytics.php
+++ b/ganalytics.php
@@ -8,7 +8,7 @@
 * that is bundled with this package in the file LICENSE.txt.
 * It is also available through the world-wide-web at this URL:
 * http://opensource.org/licenses/afl-3.0.php
-* If you did not receive a copy of the license and are unable toc
+* If you did not receive a copy of the license and are unable to
 * obtain it through the world-wide-web, please send an email
 * to license@prestashop.com so we can send you a copy immediately.
 *


### PR DESCRIPTION
In Dispatcher class, in method getController:

```
    $this->controller = str_replace('-', '', $controller);
    $_GET['controller'] = $this->controller;
```

so the controller name is stripped of every '-'

transactions are not being recorded because of this
