### PR TITLE
[-] MO Class not found 500 error

### DIFF
--- a/controllers/front/ajax.php
+++ b/controllers/front/ajax.php
@@ -24,7 +24,7 @@
 *  International Registered Trademark & Property of PrestaShop SA
 */
 
-class GanalyticsajaxModuleFrontController extends ModuleFrontController
+class GanalyticsAjaxModuleFrontController extends ModuleFrontController
 {
 	/*
 	 * @see FrontController::initContent()


### PR DESCRIPTION
The module was renamed, but the class names of the controllers was not.
