### PR TITLE
[-] MO Class not found 500 error

### DIFF
--- a/controllers/front/action.php
+++ b/controllers/front/action.php
@@ -24,7 +24,7 @@
 *  International Registered Trademark & Property of PrestaShop SA
 */
 
-class GanalyticsactionModuleFrontController extends ModuleFrontController
+class GanalyticsActionModuleFrontController extends ModuleFrontController
 {
 	/*
 	 * @see FrontController::initContent()


### PR DESCRIPTION
The module was renamed, but the class names was not, this caused a 500 error when class could not be found.
