### PR TITLE
[-] MO: ganalytics: product impression missing

### DIFF
--- a/ganalytics.php
+++ b/ganalytics.php
@@ -292,7 +292,8 @@ class Ganalytics extends Module
 		if ($controller_name == 'orderconfirmation')
 			$this->eligible = 1;
 
-		if (isset($products) && count($products))
+		$home_hook_id = Hook::getIdByName('home');
+		if (isset($products) && count($products) && !isset(Hook::$executed_hooks[$home_hook_id]))
 		{
 			if ($this->eligible == 0)
 				$ga_scripts .= $this->addProductImpression($products);

--- a/ganalytics.php
+++ b/ganalytics.php
@@ -290,7 +290,10 @@ class Ganalytics extends Module
 		}
 
 		if ($controller_name == 'orderconfirmation')
+		{
+			$this->js_state = 1;
 			$this->eligible = 1;
+		}
 
 		$home_hook_id = Hook::getIdByName('home');
 		if (isset($products) && count($products) && !isset(Hook::$executed_hooks[$home_hook_id]))

--- a/ganalytics.php
+++ b/ganalytics.php
@@ -277,14 +277,14 @@ class Ganalytics extends Module
 		}
 
 		$controller_name = Tools::getValue('controller');
-
+		$products = $this->wrapProducts($this->context->smarty->getTemplateVars('products'), array(), true);
+		
 		if ($controller_name == 'order')
 		{
 			$this->eligible = 1;
 			$step = Tools::getValue('step');
 			if (empty($step))
 				$step = 0;
-			$products = $this->wrapProducts($this->context->smarty->getTemplateVars('products'), array(), true);
 			$ga_scripts .= $this->addProductFromCheckout($products, $step);
 			$ga_scripts .= 'MBG.addCheckout(\''.(int)$step.'\');';
 		}

--- a/ganalytics.php
+++ b/ganalytics.php
@@ -290,10 +290,7 @@ class Ganalytics extends Module
 		}
 
 		if ($controller_name == 'orderconfirmation')
-		{
-			$this->js_state = 1;
 			$this->eligible = 1;
-		}
 
 		$home_hook_id = Hook::getIdByName('home');
 		if (isset($products) && count($products) && !isset(Hook::$executed_hooks[$home_hook_id]))

--- a/ganalytics.php
+++ b/ganalytics.php
@@ -292,8 +292,7 @@ class Ganalytics extends Module
 		if ($controller_name == 'orderconfirmation')
 			$this->eligible = 1;
 
-		$home_hook_id = Hook::getIdByName('home');
-		if (isset($products) && count($products) && !isset(Hook::$executed_hooks[$home_hook_id]))
+		if (isset($products) && count($products) && $controller_name != 'index'))
 		{
 			if ($this->eligible == 0)
 				$ga_scripts .= $this->addProductImpression($products);


### PR DESCRIPTION
product impressions only displayed in homepage, missing everywhere else (category, search results, manufacturer products, prices-drop,new products, best sellers.....)
We should also add it to the blocklayered module, but there is no hook for that.