### PR TITLE
[-] MO: ganalytics: Still mixed content

### DIFF
--- a/controllers/front/action.php
+++ b/controllers/front/action.php
@@ -26,6 +26,7 @@
 
 class GanalyticsActionModuleFrontController extends ModuleFrontController
 {
+	public $ssl = true;
 	/*
 	 * @see FrontController::initContent()
 	 */

--- a/controllers/front/ajax.php
+++ b/controllers/front/ajax.php
@@ -26,6 +26,7 @@
 
 class GanalyticsAjaxModuleFrontController extends ModuleFrontController
 {
+	public $ssl = true;
 	/*
 	 * @see FrontController::initContent()
 	 */


### PR DESCRIPTION
Although now the links were fixed since commit https://github.com/PrestaShop/ganalytics/commit/b241ebb3aaf45b0d685474a25216f7a9c309c282,
it still returns mixed content error becuase, when this controllers are loaded, they are redirected to the non-ssl version