### PR TITLE
[-] MO: ganalytics: backoffice is tracking visits

### DIFF
--- a/ganalytics.php
+++ b/ganalytics.php
@@ -322,10 +322,7 @@ class Ganalytics extends Module
 
 		$confirmation_hook_id = Hook::getIdByName('orderConfirmation');
 		if (isset(Hook::$executed_hooks[$confirmation_hook_id]))
-		{
-			$this->js_state = 1;
 			$this->eligible = 1;
-		}
 
 		if (isset($products) && count($products) && $controller_name != 'index')
 		{

--- a/views/js/GoogleAnalyticActionLib.js
+++ b/views/js/GoogleAnalyticActionLib.js
@@ -105,6 +105,7 @@ var GoogleAnalyticEnhancedECommerce = {
 		ga('ec:setAction', 'refund', {
 			'id': Order.id // Transaction ID is only required field for full refund.
 		});
+		ga('send', 'event','Refund','refund',{'nonInteraction':1});
 	},
 
 	refundByProduct: function(Order) {
@@ -116,7 +117,7 @@ var GoogleAnalyticEnhancedECommerce = {
 		ga('ec:setAction', 'refund', {
 			'id': Order.Id, // Transaction ID is required for partial refund.
 		});
-		//ga('send', 'pageview');
+		ga('send', 'event','Refund','refund',{'nonInteraction':1});
 	},
 
 	addProductClick: function(Product) {
@@ -156,7 +157,7 @@ var GoogleAnalyticEnhancedECommerce = {
 
 		//this.add(Product);
 		ga('ec:setAction', 'purchase', Order);
-		ga('send', 'pageview', {
+		ga('send', 'event','Transaction','purchase', {
 			'hitCallback': function() {
 				$.get(Order.url, {
 					orderid: Order.id

--- a/views/js/GoogleAnalyticActionLib.js
+++ b/views/js/GoogleAnalyticActionLib.js
@@ -105,7 +105,7 @@ var GoogleAnalyticEnhancedECommerce = {
 		ga('ec:setAction', 'refund', {
 			'id': Order.id // Transaction ID is only required field for full refund.
 		});
-		ga('send', 'event','Refund','refund',{'nonInteraction':1});
+		ga('send', 'event', 'Ecommerce', 'Refund', {'nonInteraction': 1});
 	},
 
 	refundByProduct: function(Order) {
@@ -117,7 +117,7 @@ var GoogleAnalyticEnhancedECommerce = {
 		ga('ec:setAction', 'refund', {
 			'id': Order.Id, // Transaction ID is required for partial refund.
 		});
-		ga('send', 'event','Refund','refund',{'nonInteraction':1});
+		ga('send', 'event', 'Ecommerce', 'Refund', {'nonInteraction': 1});
 	},
 
 	addProductClick: function(Product) {


### PR DESCRIPTION
with this changes, the only pageview left is sent from hookfooter, no more accidental pageviews sent from the js library