### PR TITLE
[-]MO ganalytics: Typo in js lib and google recommenadation

### DIFF
--- a/ganalytics.php
+++ b/ganalytics.php
@@ -226,8 +226,8 @@ class Ganalytics extends Module
 				m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
 				})(window,document,\'script\',\'//www.google-analytics.com/analytics.js\',\'ga\');
 				ga(\'create\', \''.Tools::safeOutput(Configuration::get('GA_ACCOUNT_ID')).'\', \'auto\');
-				'.($back_office ? 'ga(\'require\', \'ecommerce\');' : '').'
 				ga(\'require\', \'ec\');
+				'.($back_office ? 'ga(\'set\', \'nonInteraction\', true);' : '').'
 			</script>';
 	}
 

--- a/views/js/GoogleAnalyticActionLib.js
+++ b/views/js/GoogleAnalyticActionLib.js
@@ -114,7 +114,7 @@ var GoogleAnalyticEnhancedECommerce = {
 		//this.add(Product);
 
 		ga('ec:setAction', 'refund', {
-			'id': Order.Id, // Transaction ID is required for partial refund.
+			'id': Order.id, // Transaction ID is required for partial refund.
 		});
 		//ga('send', 'pageview');
 	},


### PR DESCRIPTION
In backoffice it is using ecommerce.js and ecommerce.js and analytics.js should never be used in the same proprerty:
"Important: The Enhanced Ecommerce plug-in should not be used alongside the Ecommerce (ecommerce.js) plug-in for the same property." (https://developers.google.com/analytics/devguides/collection/analyticsjs/enhanced-ecommerce)