### PR TITLE
[-] MO ganalytics: duplicated transaction from BO

### DIFF
--- a/ganalytics.php
+++ b/ganalytics.php
@@ -628,7 +628,7 @@ class Ganalytics extends Module
 			$this->context->smarty->assign('GA_ACCOUNT_ID', $ga_account_id);
 
 			$ga_scripts = '';
-			$ga_order_records = Db::getInstance()->ExecuteS('SELECT * FROM `'._DB_PREFIX_.'ganalytics` WHERE sent = 0');
+			$ga_order_records = Db::getInstance()->ExecuteS('SELECT * FROM `'._DB_PREFIX_.'ganalytics` WHERE sent = 0 AND DATE_ADD(date_add, INTERVAL 20 minute) < NOW()');
 
 			if ($ga_order_records)
 				foreach ($ga_order_records as $row)


### PR DESCRIPTION
When a pageload is done from the backoffice after the transaction is added to ganalytics table and before the callbackk is called and it is set to 1, the transaction will be sent twice, once from the front office by the customer, and once from the backoffice.
Added a 20 minutes delay to avoid this.