### PR TITLE
Add static array to avoid removing from cart two times

### DIFF
--- a/ganalytics.php
+++ b/ganalytics.php
@@ -667,7 +667,7 @@ class Ganalytics extends Module
 	{
 		if (!isset($this->context->cart))
 			return;
-		
+
 		$ga_scripts  = '';
 
 		$cart = array(

--- a/ganalytics.php
+++ b/ganalytics.php
@@ -32,6 +32,7 @@ class Ganalytics extends Module
 	protected $js_state = 0;
 	protected $eligible = 0;
 	protected $filterable = 1;
+	protected static $products = array();
 
 	public function __construct()
 	{
@@ -666,7 +667,7 @@ class Ganalytics extends Module
 	{
 		if (!isset($this->context->cart))
 			return;
-
+		
 		$ga_scripts  = '';
 
 		$cart = array(
@@ -703,8 +704,9 @@ class Ganalytics extends Module
 			}
 		}
 
-		if (isset($add_product))
+		if (isset($add_product) && !in_array((int)Tools::getValue('id_product'), static::$products))
 		{
+			static::$products[] = (int)Tools::getValue('id_product');
 			$ga_products = $this->wrapProduct($add_product, array(), 0, true);
 
 			if ($cart['removeAction'] == 'delete' || $cart['extraAction'] == 'down')


### PR DESCRIPTION
As already reported by @prestachris, we have a removeFromCart notification which is sent two times. We add a static array to correct this issue.