### PR TITLE
Return true when no tabs needs to be uninstalled

### DIFF
--- a/ganalytics.php
+++ b/ganalytics.php
@@ -122,8 +122,8 @@ class Ganalytics extends Module
 			$tab = new Tab($id_tab);
 			return $tab->delete();
 		}
-		else
-			return false;
+
+		return true;
 	}
 
 	public function displayForm()


### PR DESCRIPTION
If the tab is not found, there is nothing to do. We do not need to return false which will be detected as an error.

See https://twitter.com/PrestaPlugins/status/569452932091027456 (in French) for more information.