### PR TITLE
[-] MO : ganalytics: Remove product ref from ID product

### DIFF
--- a/ganalytics.php
+++ b/ganalytics.php
@@ -684,7 +684,7 @@ class Ganalytics extends Module
 		{
 			// Display GA refund product
 			$order_detail = new OrderDetail($orderdetail_id);
-			$ga_scripts .= 'MBG.add('.Tools::jsonEncode(array('id' => empty($order_detail->product_reference)?$order_detail->product_id:$order_detail->product_reference, 'quantity' => $qty)).');';
+			$ga_scripts .= 'MBG.add('.Tools::jsonEncode(array('id' => empty($order_detail->product_id)?$order_detail->product_id:$order_detail->product_id, 'quantity' => $qty)).');';
 		}
 		$this->context->cookie->ga_admin_refund = $ga_scripts.'MBG.refundByProduct('.Tools::jsonEncode(array('id' => $params['order']->id)).');';
 	}

--- a/ganalytics.php
+++ b/ganalytics.php
@@ -471,6 +471,9 @@ class Ganalytics extends Module
 				$product_id = $product['id_product'];
 			else if (!empty($product['id']))
 				$product_id = $product['id'];
+				
+			if (!empty($product['id_product_attribute']))
+				$product_id .= '-'. $product['id_product_attribute'];
 
 			$product_type = 'typical';
 			if (isset($product['pack']) && $product['pack'] == 1)
@@ -684,7 +687,7 @@ class Ganalytics extends Module
 		{
 			// Display GA refund product
 			$order_detail = new OrderDetail($orderdetail_id);
-			$ga_scripts .= 'MBG.add('.Tools::jsonEncode(array('id' => empty($order_detail->product_id)?$order_detail->product_id:$order_detail->product_id, 'quantity' => $qty)).');';
+			$ga_scripts .= 'MBG.add('.Tools::jsonEncode(array('id' => empty($order_detail->product_attribute_id)?$order_detail->product_id:$order_detail->product_id.'-'.$order_detail->product_attribute_id, 'quantity' => $qty)).');';
 		}
 		$this->context->cookie->ga_admin_refund = $ga_scripts.'MBG.refundByProduct('.Tools::jsonEncode(array('id' => $params['order']->id)).');';
 	}

--- a/ganalytics.php
+++ b/ganalytics.php
@@ -467,9 +467,7 @@ class Ganalytics extends Module
 		if ($full)
 		{
 			$product_id = 0;
-			if (!empty($product['reference']))
-				$product_id = $product['reference'];
-			else if (!empty($product['id_product']))
+			if (!empty($product['id_product']))
 				$product_id = $product['id_product'];
 			else if (!empty($product['id']))
 				$product_id = $product['id'];


### PR DESCRIPTION
Using product reference instead of product ID makes problems with Merchant Center and Adword's remarketing.