### PR TITLE
Avoid double register a transaction if the order is already registere…

### DIFF
--- a/ganalytics.php
+++ b/ganalytics.php
@@ -706,7 +706,11 @@ class Ganalytics extends Module
 			if ($this->context->controller->controller_name == 'AdminOrders')
 			{
 				if (Tools::getValue('id_order'))
-					Db::getInstance()->Execute('INSERT IGNORE INTO `'._DB_PREFIX_.'ganalytics` (id_order, id_shop, sent, date_add) VALUES ('.(int)Tools::getValue('id_order').', '.(int)$this->context->shop->id.', 0, NOW())');
+				{
+					$ga_order_sent = Db::getInstance()->getValue('SELECT id_order FROM `'._DB_PREFIX_.'ganalytics` WHERE id_order = '.(int)Tools::getValue('id_order'));
+					if ($ga_order_sent === false)
+						Db::getInstance()->Execute('INSERT IGNORE INTO `'._DB_PREFIX_.'ganalytics` (id_order, id_shop, sent, date_add) VALUES ('.(int)Tools::getValue('id_order').', '.(int)$this->context->shop->id.', 0, NOW())');
+				}
 				else
 				{
 					$ga_order_records = Db::getInstance()->ExecuteS('SELECT * FROM `'._DB_PREFIX_.'ganalytics` WHERE sent = 0 AND id_shop = \''.(int)$this->context->shop->id.'\' AND DATE_ADD(date_add, INTERVAL 30 minute) < NOW()');


### PR DESCRIPTION
…d on ganalytics table.

If we keep the INSERT IGNORE every time we access the order trough the backend a new record is inserted no matter if the transaction was already reported or is pending and it literally make a chaos on Google Analytics. Yesterday I have more than 2000 duplicated transactions on Google Analytics. 

This is just a quick fix to avoid duplicated transactions. 

Signed-off-by: David Gonzalez <david@justclickcorp.com>