### PR TITLE
[*] MO: ganalytics anonymizeIp feature added as selectable option

### DIFF
--- a/ganalytics.php
+++ b/ganalytics.php
@@ -197,6 +197,24 @@ class Ganalytics extends Module
 						),
 					),
 				),
+				array(
+					'type' => 'radio',
+					'label' => $this->l('Enable AnonymizeIp'),
+					'name' => 'GA_ANONYMIZEIP_ENABLED',
+					'hint' => $this->l('If enabled, prevents Google from saving the full IP address for a visitor.'),
+					'values'    => array(
+						array(
+							'id' => 'ga_anonymizeip_enabled',
+							'value' => 1,
+							'label' => $this->l('Enabled')
+						),
+						array(
+							'id' => 'ga_anonymizeip_disabled',
+							'value' => 0,
+							'label' => $this->l('Disabled')
+						),
+					),
+				),
 			),
 			'submit' => array(
 				'title' => $this->l('Save'),
@@ -206,6 +224,7 @@ class Ganalytics extends Module
 		// Load current value
 		$helper->fields_value['GA_ACCOUNT_ID'] = Configuration::get('GA_ACCOUNT_ID');
 		$helper->fields_value['GA_USERID_ENABLED'] = Configuration::get('GA_USERID_ENABLED');
+		$helper->fields_value['GA_ANONYMIZEIP_ENABLED'] = Configuration::get('GA_ANONYMIZEIP_ENABLED');
 
 		return $helper->generateForm($fields_form);
 	}
@@ -231,6 +250,12 @@ class Ganalytics extends Module
 				Configuration::updateValue('GA_USERID_ENABLED', (bool)$ga_userid_enabled);
 				$output .= $this->displayConfirmation($this->l('Settings for User ID updated successfully'));
 			}
+			$ga_anonymizeip_enabled = Tools::getValue('GA_ANONYMIZEIP_ENABLED');
+			if (null !== $ga_anonymizeip_enabled)
+			{
+				Configuration::updateValue('GA_ANONYMIZEIP_ENABLED', (bool)$ga_anonymizeip_enabled);
+				$output .= $this->displayConfirmation($this->l('Settings for AnonymizeIp updated successfully'));
+			}
 		}
 
 		if (version_compare(_PS_VERSION_, '1.5', '>='))
@@ -249,10 +274,15 @@ class Ganalytics extends Module
 	protected function _getGoogleAnalyticsTag($back_office = false)
 	{
 		$user_id = null;
+		$anonymizeip = false;
 		if (Configuration::get('GA_USERID_ENABLED') &&
 			$this->context->customer && $this->context->customer->isLogged()
 		){
 			$user_id = (int)$this->context->customer->id;
+		}
+
+		if (Configuration::get('GA_ANONYMIZEIP_ENABLED')) {
+			$anonymizeip = true;
 		}
 
 		return '
@@ -266,6 +296,7 @@ class Ganalytics extends Module
 				ga(\'require\', \'ec\');'
 				.(($user_id && !$back_office) ? 'ga(\'set\', \'&uid\', \''.$user_id.'\');': '')
 				.($back_office ? 'ga(\'set\', \'nonInteraction\', true);' : '')
+				.($anonymizeip ? 'ga(\'set\', \'anonymizeIp\', true);' : '')
 			.'</script>';
 	}
 

--- a/upgrade/Upgrade-2.3.4.php
+++ b/upgrade/Upgrade-2.3.4.php
@@ -1,0 +1,32 @@
+<?php
+/**
+* 2007-2015 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author    PrestaShop SA <contact@prestashop.com>
+*  @copyright 2007-2015 PrestaShop SA
+*  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*/
+if (!defined('_PS_VERSION_'))
+	exit;
+function upgrade_module_2_3_4($object)
+{
+	Configuration::updateValue('GA_ANONYMIZEIP_ENABLED', false);
+	return true;
+}


### PR DESCRIPTION
Added the anonymizeIp-Feature for Google Analytics as a selectable setting in the configure-dialog as asked in #84 

i didn't added the form-controls to the `form-ps14.tpl`, because the userid feature wasn't added there, too. at the moment i did not add translations for the new feature. is this needed for the PR to be accepted?

I added a new `Upgrade-2.3.4.php` file, to set a default value to the config.