### PR TITLE
[-] MO ganalytics Fixes 78 checkout steps not being sent to google Analytics

### DIFF
--- a/ganalytics.php
+++ b/ganalytics.php
@@ -364,6 +364,7 @@ class Ganalytics extends Module
 
 		if ($controller_name == 'order' || $controller_name == 'orderopc')
 		{
+			$this->js_state = 0;
 			$this->eligible = 1;
 			$step = Tools::getValue('step');
 			if (empty($step))

--- a/ganalytics.php
+++ b/ganalytics.php
@@ -364,7 +364,7 @@ class Ganalytics extends Module
 
 		if ($controller_name == 'order' || $controller_name == 'orderopc')
 		{
-			$this->js_state = 0;
+			$this->js_state = 1;
 			$this->eligible = 1;
 			$step = Tools::getValue('step');
 			if (empty($step))

--- a/views/js/GoogleAnalyticActionLib.js
+++ b/views/js/GoogleAnalyticActionLib.js
@@ -173,6 +173,6 @@ var GoogleAnalyticEnhancedECommerce = {
 			'step': Step
 			//'option':'Visa'
 		});
-		//ga('send', 'pageview');
+		ga('send', 'pageview');
 	}
 };


### PR DESCRIPTION
Google Analytics ecommerce data has to be sent along with a hit, like `pageview` or event. However, for some reason, the `pageview` hit inserted in a separate `<script>` tag (in `_getGoogleAnalyticsTag()`) is often sent *before* the ecommerce data is set, resulting in no checkout steps being sent. 

Since checkout steps do not send an `event` hit type in the JS lib, we need to send a `pageview` hit right after setting the ecommerce data. We also set `$js-state` to 1 in the hookFooter for checkout pages so that there is no duplicate pageview sent to Google Analytics. 