### PR TITLE
New way to encode product name

### DIFF
--- a/ganalytics.php
+++ b/ganalytics.php
@@ -527,10 +527,10 @@ class Ganalytics extends Module
 		{
 			$ga_product = array(
 				'id' => $product_id,
-				'name' => Tools::jsonEncode($product['name']),
-				'category' => Tools::jsonEncode($product['category']),
-				'brand' => isset($product['manufacturer_name']) ? Tools::jsonEncode($product['manufacturer_name']) : '',
-				'variant' => Tools::jsonEncode($variant),
+				'name' => Tools::str2url($product['name']),
+				'category' => Tools::str2url($product['category']),
+				'brand' => isset($product['manufacturer_name']) ? Tools::str2url($product['manufacturer_name']) : '',
+				'variant' => Tools::str2url($variant),
 				'type' => $product_type,
 				'position' => $index ? $index : '0',
 				'quantity' => $product_qty,
@@ -543,7 +543,7 @@ class Ganalytics extends Module
 		{
 			$ga_product = array(
 				'id' => $product_id,
-				'name' => Tools::jsonEncode($product['name'])
+				'name' => Tools::str2url($product['name'])
 			);
 		}
 		return $ga_product;


### PR DESCRIPTION
If the product name has accented chars or slash data is hard to read in Analytics, because of jsonencode.
Also, if the product includes a | (pipe), it will break with a fatal error because of Cookie does not authorize this char.