### PR TITLE
[-] MO: ganalytics: misleading BO order tags

### DIFF
--- a/ganalytics.php
+++ b/ganalytics.php
@@ -646,6 +646,10 @@ class Ganalytics extends Module
 		if (Configuration::get('GA_ACCOUNT_ID'))
 		{
 			$runjs_code = '';
+                        if($backoffice){
+                            $runjs_code .= 'MBG.setCampaign(\'backoffice-orders\',\'backoffice\',\'cms\');';
+                        }
+               
 			if (!empty($js_code))
 				$runjs_code .= '
 				<script type="text/javascript">

--- a/ganalytics.php
+++ b/ganalytics.php
@@ -646,11 +646,12 @@ class Ganalytics extends Module
 		if (Configuration::get('GA_ACCOUNT_ID'))
 		{
 			$runjs_code = '';
-                        if($backoffice){
-                            $js_code .= 'MBG.setCampaign(\'backoffice-orders\',\'backoffice\',\'cms\');';
-                        }
                
-			if (!empty($js_code))
+			if (!empty($js_code)){
+	                        if($backoffice){
+                            		$js_code .= 'MBG.setCampaign(\'backoffice-orders\',\'backoffice\',\'cms\');';
+                        	}
+			
 				$runjs_code .= '
 				<script type="text/javascript">
 					jQuery(document).ready(function(){
@@ -659,6 +660,7 @@ class Ganalytics extends Module
 						'.$js_code.'
 					});
 				</script>';
+			}
 
 			if (($this->js_state) != 1 && ($backoffice == 0))
 				$runjs_code .= '

--- a/ganalytics.php
+++ b/ganalytics.php
@@ -647,7 +647,7 @@ class Ganalytics extends Module
 		{
 			$runjs_code = '';
                         if($backoffice){
-                            $runjs_code .= 'MBG.setCampaign(\'backoffice-orders\',\'backoffice\',\'cms\');';
+                            $js_code .= 'MBG.setCampaign(\'backoffice-orders\',\'backoffice\',\'cms\');';
                         }
                
 			if (!empty($js_code))

--- a/views/js/GoogleAnalyticActionLib.js
+++ b/views/js/GoogleAnalyticActionLib.js
@@ -30,6 +30,12 @@ var GoogleAnalyticEnhancedECommerce = {
 	setCurrency: function(Currency) {
 		ga('set', '&cu', Currency);
 	},
+	
+        setCampaign: function(Name,Source,Medium){
+            ga('set', 'campaignName', Name);
+            ga('set', 'campaignSource', Source);
+            ga('set', 'campaignMedium', Medium);
+        },
 
 	add: function(Product, Order, Impression) {
 		var Products = {};


### PR DESCRIPTION
If I go to manage my twitter account (or facebook, or test a new campaign) and then I go into the back office, my gAnalytics cookies send backoffice orders and tagged with my cookies (for example I get a bunch of orders coming from twitter, when I don't even have the account set)
This is creating false information in gAnalytis
