### PR TITLE
MO: Prevent 307 internal redirect

### DIFF
--- a/ganalytics.php
+++ b/ganalytics.php
@@ -261,7 +261,7 @@ class Ganalytics extends Module
 				(function(i,s,o,g,r,a,m){i[\'GoogleAnalyticsObject\']=r;i[r]=i[r]||function(){
 				(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
 				m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-				})(window,document,\'script\',\'//www.google-analytics.com/analytics.js\',\'ga\');
+				})(window,document,\'script\',\'https://www.google-analytics.com/analytics.js\',\'ga\');
 				ga(\'create\', \''.Tools::safeOutput(Configuration::get('GA_ACCOUNT_ID')).'\', \'auto\');
 				ga(\'require\', \'ec\');'
 				.(($user_id && !$back_office) ? 'ga(\'set\', \'&uid\', \''.$user_id.'\');': '')


### PR DESCRIPTION
If the shop is running without SSL it will try to access analytics.js over HTTP and be redirected to HTTPS.
This solve the redirect as it now always request it over HTTPS
