### PR TITLE
Remove jQuery

### DIFF
--- a/ganalytics.php
+++ b/ganalytics.php
@@ -649,11 +649,9 @@ class Ganalytics extends Module
 			if (!empty($js_code))
 				$runjs_code .= '
 				<script type="text/javascript">
-					jQuery(document).ready(function(){
-						var MBG = GoogleAnalyticEnhancedECommerce;
-						MBG.setCurrency(\''.Tools::safeOutput($this->context->currency->iso_code).'\');
-						'.$js_code.'
-					});
+					var MBG = GoogleAnalyticEnhancedECommerce;
+					MBG.setCurrency(\''.Tools::safeOutput($this->context->currency->iso_code).'\');
+					'.$js_code.'
 				</script>';
 
 			if (($this->js_state) != 1 && ($backoffice == 0))


### PR DESCRIPTION
jQuery(document).ready(function(){ is not needed because the code is loaded at the end of the page. (and this makes an error in the page when jquery is not available in the window, which is my case) Thanks