### PR TITLE
MO: Replaced &uid with userId

### DIFF
--- a/ganalytics.php
+++ b/ganalytics.php
@@ -264,7 +264,7 @@ class Ganalytics extends Module
 				})(window,document,\'script\',\'//www.google-analytics.com/analytics.js\',\'ga\');
 				ga(\'create\', \''.Tools::safeOutput(Configuration::get('GA_ACCOUNT_ID')).'\', \'auto\');
 				ga(\'require\', \'ec\');'
-				.(($user_id && !$back_office) ? 'ga(\'set\', \'&uid\', \''.$user_id.'\');': '')
+				.(($user_id && !$back_office) ? 'ga(\'set\', \'userId\', \''.$user_id.'\');': '')
 				.($back_office ? 'ga(\'set\', \'nonInteraction\', true);' : '')
 			.'</script>';
 	}


### PR DESCRIPTION
Google Analytics documentation suggests to set the user id like this:
`ga('set', 'userId', USER_ID);`

[https://developers.google.com/analytics/devguides/collection/analyticsjs/cookies-user-id](url)