### PR TITLE
Google doesn't handle comma thousand separator.

### DIFF
--- a/ganalytics.php
+++ b/ganalytics.php
@@ -537,7 +537,7 @@ class Ganalytics extends Module
 				'quantity' => $product_qty,
 				'list' => Tools::getValue('controller'),
 				'url' => isset($product['link']) ? urlencode($product['link']) : '',
-				'price' => number_format($product['price'], '2')
+				'price' => number_format($product['price'], 2, '.', '')
 			);
 		}
 		else


### PR DESCRIPTION
By leaving number_format open for implementation per locale, the resulting json data will not be consistent.
Google seemingly doesnt handle comma separated thousands resulting in erronous prices for certain locales (Swedish tested).

Instead include these additional parameters to force decimal separator '.' and no thousand separator,
to ensure product prices sent to google is correct.